### PR TITLE
fix: small typo in JSON schema of Count Up

### DIFF
--- a/src/count-up/count-up.schema.json
+++ b/src/count-up/count-up.schema.json
@@ -4,7 +4,7 @@
   "title": "Count Up",
   "allOf": [
     {
-      "$ref": "http://frontend.ruhmesmeile.com/content/content/count-up.schema.json"
+      "$ref": "http://frontend.ruhmesmeile.com/content/molecules/count-up.schema.json"
     },
     {
       "type": "object",


### PR DESCRIPTION
See related issue: https://github.com/kickstartDS/kickstartDS-storybook/issues/15
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.3.1--canary.16.565.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @kickstartds/design-system@1.3.1--canary.16.565.0
  # or 
  yarn add @kickstartds/design-system@1.3.1--canary.16.565.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
