### PR TITLE
fix: image in related glossary term

### DIFF
--- a/src/Pages/GlossaryEntry.story.jsx
+++ b/src/Pages/GlossaryEntry.story.jsx
@@ -30,11 +30,13 @@ const Page = () => (
       related={[{
         title: "ECMAScript 6 (ES6)",
         excerpt: "ES6 is the specific flavour of JavaScript we're writing for it's much improved module support, making 100% vanilla JavaScript solutions a reality. It is also much more terse and expressive in its syntax (iterators, destructuring, arrow functions, etc).",
-        url: "https://www.kickstartds.com/glossary/es6/"
+        url: "https://www.kickstartds.com/glossary/es6/",
+        image: "https://raw.githubusercontent.com/github/explore/e4270e345b968ae626310bc86e339a2ae80c6ae4/topics/ecmascript/ecmascript.png"
       }, {
         title: "JavaScript",
         excerpt: "JavaScript for us has two uses. On the one hand it is the foundation for progressively layered interactivity on a website / interface built with kickstartDS, and on the other hand it's at the core of the engine powering quality and developer experience in modern web frameworks: build tooling, bundling, semantic versioning, testing, etc.",
-        url: "https://www.kickstartds.com/glossary/javascript/"
+        url: "https://www.kickstartds.com/glossary/javascript/",
+        image: "https://upload.wikimedia.org/wikipedia/commons/thumb/9/99/Unofficial_JavaScript_logo_2.svg/480px-Unofficial_JavaScript_logo_2.svg.png"
       }]}
       stackshare="https://stackshare.io/julrich/decisions/107140151808024329"
     />

--- a/src/glossary/GlossaryComponent.jsx
+++ b/src/glossary/GlossaryComponent.jsx
@@ -199,9 +199,10 @@ export const Glossary = ({
         {related?.map((item, i) => (
           <ContentBox
             alignement="left"
-            image={item.url}
+            image={item.image}
             className="related-post"
             link={{
+              href: item.url,
               enabled: true,
               label: "Keep reading",
               variant: "clear",

--- a/src/glossary/glossary.schema.json
+++ b/src/glossary/glossary.schema.json
@@ -98,7 +98,14 @@
             "title": "Url",
             "type": "string",
             "description": "Url for the related term",
-            "default": "https://picsum.photos/seed/glossary-related-media/640/480"
+            "default": "/glossary/design-token/"
+          },
+          "image": {
+            "title": "Image",
+            "type": "string",
+            "format": "image",
+            "default": "https://picsum.photos/seed/glossary-related-media-01/640/480",
+            "description": "Image for the related term"
           }
         }
       }


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.10.2--canary.35.1016.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @kickstartds/design-system@1.10.2--canary.35.1016.0
  # or 
  yarn add @kickstartds/design-system@1.10.2--canary.35.1016.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
