### PR TITLE
fix: witdh of logo on safari

### DIFF
--- a/src/logo/_logo.scss
+++ b/src/logo/_logo.scss
@@ -9,7 +9,7 @@
     position: relative;
     display: block;
     height: var(--g-logo-height);
-    width: auto;
+    width: fit-content;
     transition: height var(--g-transition-duration-s);
 
     img {


### PR DESCRIPTION
Always use a sensible width for the main logo. Was being buggy on Safari before! Already fixed on next major release, but now also as a hotfix.